### PR TITLE
add timeout multishot flag

### DIFF
--- a/include.go
+++ b/include.go
@@ -187,6 +187,7 @@ const (
 	TimeoutRealtime
 	LinkTimeoutUpdate
 	TimeoutETimeSuccess
+	TimeoutMultishot
 	TimeoutClockMask  = TimeoutBoottime | TimeoutRealtime
 	TimeoutUpdateMask = TimeoutUpdate | LinkTimeoutUpdate
 )


### PR DESCRIPTION
It is part of the liburing 2.4 since
[this](https://github.com/axboe/liburing/commit/d57fa5b86d21e77ddba248c3801b0d329b72e045) commit.