### PR TITLE
fix SQE PrepareConnect method

### DIFF
--- a/network_connect_test.go
+++ b/network_connect_test.go
@@ -1,0 +1,184 @@
+package giouring
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	. "github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestNetworkConnectWrite(t *testing.T) {
+	listen, err := net.Listen("tcp", "127.0.0.1:0")
+	NoError(t, err)
+	_, portStr, err := net.SplitHostPort(listen.Addr().String())
+	NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	NoError(t, err)
+	// t.Logf("running test server at port %d", port)
+
+	data := []byte("testdata1234567890")
+	go func() {
+		ring, err := CreateRing(16)
+		NoError(t, err)
+		defer ring.QueueExit()
+
+		// create a TCP socket
+		fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+		NoError(t, err)
+
+		// prepare connect
+		sqe := ring.GetSQE()
+		NotNil(t, sqe)
+
+		sa := syscall.SockaddrInet4{Port: port}
+		err = sqe.PrepareConnect(fd, &sa)
+		NoError(t, err)
+		sqe.UserData = connectFlag
+
+		// submit, wait for connect to complete
+		cqe := testSubmitWaitCQE(t, ring, connectFlag)
+		True(t, cqe.Res == 0)
+
+		// prepare send
+		sqe = ring.GetSQE()
+		NotNil(t, sqe)
+		sqe.PrepareSend(fd, uintptr(unsafe.Pointer(&data[0])), uint32(len(data)), 0)
+		sqe.UserData = sendFlag
+
+		// submit, wait for completion, test completion
+		cqe = testSubmitWaitCQE(t, ring, sendFlag)
+		True(t, cqe.Res > 0)
+		True(t, int(cqe.Res) == len(data))
+
+		// prepare and wait for shutdown
+		sqe = ring.GetSQE()
+		sqe.PrepareShutdown(fd, 1)
+		sqe.UserData = connectFlag
+		cqe = testSubmitWaitCQE(t, ring, connectFlag)
+		True(t, cqe.Res == 0)
+	}()
+
+	// read into readBuffer until eof
+	var readBuffer []byte
+	conn, err := listen.Accept()
+	NoError(t, err)
+	chunk := make([]byte, 8)
+	for {
+		n, err := conn.Read(chunk)
+		if n == 0 {
+			break
+		}
+		NoError(t, err)
+		True(t, n >= 0)
+		readBuffer = append(readBuffer, chunk[:n]...)
+	}
+	conn.Close()
+	listen.Close()
+
+	Equal(t, data, readBuffer)
+}
+
+func TestNetworkAcceptRead(t *testing.T) {
+	ring, err := CreateRing(16)
+	NoError(t, err)
+	defer ring.QueueExit()
+
+	// prepare accept
+	fd, port := testListen(t)
+	// t.Logf("running test server at port %d", port)
+	sqe := ring.GetSQE()
+	NotNil(t, sqe)
+	sqe.PrepareAccept(fd, 0, 0, 0)
+	sqe.UserData = acceptFlag
+
+	// tcp connect and write data
+	data := []byte("testdata1234567890")
+	go func() {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), time.Second)
+		Nil(t, err)
+		NotNil(t, conn)
+		n, err := conn.Write(data)
+		NoError(t, err)
+		Equal(t, len(data), n)
+		conn.Close()
+	}()
+
+	// submit and wait for accept to complete, get connection fd
+	cqe := testSubmitWaitCQE(t, ring, acceptFlag)
+	True(t, cqe.Res > 0)
+	connFd := int(cqe.Res)
+
+	// receive in chunks
+	var recvBuffer []byte
+	chunk := make([]byte, 8)
+	for {
+		// prepare recv
+		sqe := ring.GetSQE()
+		NotNil(t, sqe)
+		sqe.PrepareRecv(connFd, uintptr(unsafe.Pointer(&chunk[0])), uint32(len(chunk)), 0)
+		sqe.UserData = recvFlag
+
+		// submit and wait for recv to complete
+		cqe := testSubmitWaitCQE(t, ring, recvFlag)
+		True(t, cqe.Res >= 0)
+
+		n := int(cqe.Res)
+		// t.Logf("read %d bytes %s", n, chunk[0:n])
+		True(t, n >= 0)
+		if n == 0 {
+			break
+		}
+		recvBuffer = append(recvBuffer, chunk[:n]...)
+	}
+
+	Equal(t, len(data), len(recvBuffer))
+	Equal(t, data, recvBuffer)
+}
+
+// test helper to submit single sqe wait for completion
+// compare completion userdata with expected
+func testSubmitWaitCQE(t *testing.T, ring *Ring, userdata uint64) *CompletionQueueEvent {
+	waitNr, err := ring.SubmitAndWait(1)
+	NoError(t, err)
+	Equal(t, uint(1), waitNr)
+	cqe, err := ring.PeekCQE()
+	NoError(t, err)
+	NotNil(t, cqe)
+	if cqe.Res < 0 {
+		t.Logf("cqe %d %d %d %s", cqe.Res, cqe.UserData, cqe.Flags, syscall.Errno(-cqe.Res))
+	}
+	True(t, cqe.Res >= 0, "result <0 means error")
+	Equal(t, userdata, cqe.UserData, "userdata should match expected operation")
+	ring.CQAdvance(1)
+	return cqe
+}
+
+// create socket and listen on OS assigned port
+// return created file descriptor and port
+func testListen(t *testing.T) (int, int) {
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+	Nil(t, err)
+	err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+	Nil(t, err)
+	err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	Nil(t, err)
+
+	sa := syscall.SockaddrInet4{}
+	err = syscall.Bind(fd, &sa)
+	Nil(t, err)
+	err = syscall.SetNonblock(fd, false)
+	Nil(t, err)
+	err = syscall.Listen(fd, 128)
+	Nil(t, err)
+
+	saAny, err := syscall.Getsockname(fd)
+	Nil(t, err)
+	port := saAny.(*syscall.SockaddrInet4).Port
+	return fd, port
+}

--- a/network_test.go
+++ b/network_test.go
@@ -42,9 +42,10 @@ const (
 	recvFlag
 	sendFlag
 	closeFlag
+	connectFlag
 )
 
-const allFlagsMask = acceptFlag | recvFlag | sendFlag | closeFlag
+const allFlagsMask = acceptFlag | recvFlag | sendFlag | closeFlag | connectFlag
 
 const (
 	acceptState = iota

--- a/prepare.go
+++ b/prepare.go
@@ -100,13 +100,8 @@ func (entry *SubmissionQueueEntry) PrepareCloseDirect(fileIndex uint32) {
 }
 
 // liburing: io_uring_prep_connect - https://manpages.debian.org/unstable/liburing-dev/io_uring_prep_connect.3.en.html
-func (entry *SubmissionQueueEntry) PrepareConnect(fd int, sa syscall.Sockaddr) error {
-	addrPtr, addrLen, errno := sockaddr(sa)
-	if errno != 0 {
-		return errno
-	}
-	entry.prepareRW(OpConnect, fd, uintptr(addrPtr), 0, uint64(addrLen))
-	return nil
+func (entry *SubmissionQueueEntry) PrepareConnect(fd int, addr uintptr, addrLen uint64) {
+	entry.prepareRW(OpConnect, fd, addr, 0, addrLen)
 }
 
 // io_uring_prep_fadvise - https://manpages.debian.org/unstable/liburing-dev/io_uring_prep_fadvise.3.en.html
@@ -599,77 +594,4 @@ func (entry *SubmissionQueueEntry) PrepareCmdSock(
 	// io_uring_prep_rw(IORING_OP_URING_CMD, sqe, fd, nil, 0, 0)
 	entry.prepareRW(OpUringCmd, fd, 0, 0, 0)
 	entry.Off = uint64(cmdOp << bit32Offset)
-}
-
-// convert syscall.Sockaddr interface to raw pointers
-// ref: https://groups.google.com/g/golang-nuts/c/B-meiFfkmH0/m/PyFC84kPaFkJ
-func sockaddr(addr syscall.Sockaddr) (unsafe.Pointer, uint32, syscall.Errno) {
-	switch sa := addr.(type) {
-	case *syscall.SockaddrInet4:
-		return sockaddr4(sa)
-	case *syscall.SockaddrInet6:
-		return sockaddr6(sa)
-	case *syscall.SockaddrUnix:
-		return sockaddrUnix(sa)
-	default:
-		panic("unimplemented")
-	}
-}
-
-// ref: https://github.com/golang/go/blob/a40404da748f0a9c7da19b077634fd7334ca5802/src/syscall/syscall_linux.go#L514
-func sockaddr4(sa *syscall.SockaddrInet4) (unsafe.Pointer, uint32, syscall.Errno) {
-	if sa.Port < 0 || sa.Port > 0xFFFF {
-		return nil, 0, syscall.EINVAL
-	}
-	var raw syscall.RawSockaddrInet4
-	raw.Family = syscall.AF_INET
-	p := (*[2]byte)(unsafe.Pointer(&raw.Port))
-	p[0] = byte(sa.Port >> 8)
-	p[1] = byte(sa.Port)
-	raw.Addr = sa.Addr
-	return unsafe.Pointer(&raw), syscall.SizeofSockaddrInet4, 0
-}
-
-// ref: https://github.com/golang/go/blob/a40404da748f0a9c7da19b077634fd7334ca5802/src/syscall/syscall_linux.go#L526
-func sockaddr6(sa *syscall.SockaddrInet6) (unsafe.Pointer, uint32, syscall.Errno) {
-	if sa.Port < 0 || sa.Port > 0xFFFF {
-		return nil, 0, syscall.EINVAL
-	}
-	var raw syscall.RawSockaddrInet6
-	raw.Family = syscall.AF_INET6
-	p := (*[2]byte)(unsafe.Pointer(&raw.Port))
-	p[0] = byte(sa.Port >> 8)
-	p[1] = byte(sa.Port)
-	raw.Scope_id = sa.ZoneId
-	raw.Addr = sa.Addr
-	return unsafe.Pointer(&raw), syscall.SizeofSockaddrInet6, 0
-}
-
-// ref: https://github.com/golang/go/blob/a40404da748f0a9c7da19b077634fd7334ca5802/src/syscall/syscall_linux.go#L539
-func sockaddrUnix(sa *syscall.SockaddrUnix) (unsafe.Pointer, uint32, syscall.Errno) {
-	name := sa.Name
-	n := len(name)
-	var raw syscall.RawSockaddrUnix
-	if n > len(raw.Path) {
-		return nil, 0, syscall.EINVAL
-	}
-	if n == len(raw.Path) && name[0] != '@' {
-		return nil, 0, syscall.EINVAL
-	}
-	raw.Family = syscall.AF_UNIX
-	for i := 0; i < n; i++ {
-		raw.Path[i] = int8(name[i])
-	}
-	// length is family (uint16), name, NUL.
-	sl := uint32(2)
-	if n > 0 {
-		sl += uint32(n) + 1
-	}
-	if raw.Path[0] == '@' {
-		raw.Path[0] = 0
-		// Don't count trailing NUL for abstract address.
-		sl--
-	}
-
-	return unsafe.Pointer(&raw), sl, 0
 }


### PR DESCRIPTION
io_uring_prep_connect requires pointer to C `struct sockaddr` and len as parameters. To convert between `syscall.Scokaddr` interface and raw socket pointer and len standard library uses private function [sockaddr()](https://github.com/golang/go/blob/4c5130a96eabd5d9a72a43aa8e895b668fbd653b/src/syscall/syscall_unix.go#L264C35-L264C35). As advised by Russ Cox [here](https://groups.google.com/g/golang-nuts/c/B-meiFfkmH0/m/PyFC84kPaFkJ) I copied few private functions from stdlib to make that conversion for inet4, inet6 and unix domain sockets.

Make tests for connect. Using stdlib server and giouring to connect to that tcp server.